### PR TITLE
Use scikit-learn instead of deprecated sklearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         ],
     packages = find_packages(),
     install_requires=[
-        'sklearn',
+        'scikit-learn',
         'numpy',
         'pandas',
       ],


### PR DESCRIPTION
Installing dsutils fails due to sklearn being deprecated, as can be seen [here](https://github.com/scikit-learn/sklearn-pypi-package).
I have updated the reference to use the recommended scikit-learn instead